### PR TITLE
Modified the Mailbox Reporting Report

### DIFF
--- a/Office365/MailboxSizeReport.ps1
+++ b/Office365/MailboxSizeReport.ps1
@@ -34,6 +34,12 @@
 
 param(
   [Parameter(
+    Mandatory = $true,
+    HelpMessage = "Enter the Exchange Online or Global admin username"
+  )]
+  [string]$adminUPN,
+
+  [Parameter(
     Mandatory = $false,
     HelpMessage = "Get (only) Shared Mailboxes or not. Default include them"
   )]

--- a/Office365/MailboxSizeReport.ps1
+++ b/Office365/MailboxSizeReport.ps1
@@ -1,52 +1,38 @@
 <#
 .SYNOPSIS
   Create report of all mailbox and archive sizes
-
 .DESCRIPTION
   Collects all the mailbox and archive stats from Exchange Online users. By default it will also
   include the Shared Mailboxes. 
-
 .EXAMPLE
-  Get-MailboxSizeReport.ps1 -adminUPN johndoe@contoso.com
-
-  Generate the mailbox size report with Shared mailboxes, mailbox archive and store 
-  the csv file in the script root location.
-
+  Get-MailboxSizeReport.ps1
+  Generate the mailbox size report with Shared mailboxes, mailbox archive.
 .EXAMPLE
-  Get-MailboxSizeReport.ps1 -adminUPN johndoe@contoso.com -sharedMailboxes only
-
+  Get-MailboxSizeReport.ps1 -sharedMailboxes only
   Get only the shared mailboxes
-
 .EXAMPLE
-  Get-MailboxSizeReport.ps1 -adminUPN johndoe@contoso.com -sharedMailboxes no
-
+  Get-MailboxSizeReport.ps1 -sharedMailboxes no
   Get only the user mailboxes
-
 .EXAMPLE
-  Get-MailboxSizeReport.ps1 -adminUPN johndoe@contoso.com -archive:$false
-
+  Get-MailboxSizeReport.ps1 -archive:$false
   Get the mailbox size without the archive mailboxes
-
 .EXAMPLE
-  Get-MailboxSizeReport.ps1 -adminUPN johndoe@contoso.com -path c:\temp\report.csv
-
+  Get-MailboxSizeReport.ps1 -CSVpath c:\temp\report.csv
   Store CSV report in c:\temp\report.csv
-
+.EXAMPLE
+  Get-MailboxSizeReport.ps1 | Format-Table
+  Print results for mailboxes in the console and format as table
 .NOTES
-  Version:        1.2
+  Version:        1.3
   Author:         R. Mens - LazyAdmin.nl
+  Modified By:    Bradley Wyatt - The Lazy Administrator
   Creation Date:  23 sep 2021
+  Modified Date:  26 aug 2022
   Purpose/Change: Check if we have a mailbox, before running the numbers
   Link:           https://lazyadmin.nl/powershell/office-365-mailbox-size-report
 #>
 
 param(
-  [Parameter(
-    Mandatory = $true,
-    HelpMessage = "Enter the Exchange Online or Global admin username"
-  )]
-  [string]$adminUPN,
-
   [Parameter(
     Mandatory = $false,
     HelpMessage = "Get (only) Shared Mailboxes or not. Default include them"
@@ -64,7 +50,7 @@ param(
     Mandatory = $false,
     HelpMessage = "Enter path to save the CSV file"
   )]
-  [string]$path = ".\MailboxSizeReport-$((Get-Date -format "MMM-dd-yyyy").ToString()).csv"
+  [string]$CSVpath
 )
 
 Function ConnectTo-EXO {
@@ -189,12 +175,14 @@ Function Get-MailboxStats {
           "Deleted Items Size (GB)" = ConvertTo-Gb -size $mailboxSize.TotalDeletedItemSize.ToString().Split("(")[0]
           "Item Count" = $mailboxSize.ItemCount
           "Deleted Items Count" = $mailboxSize.DeletedItemCount
-          "Mailbox Warning Quota (GB)" = $_.IssueWarningQuota.ToString().Split("(")[0]
-          "Max Mailbox Size (GB)" = $_.ProhibitSendReceiveQuota.ToString().Split("(")[0]
+          "Mailbox Warning Quota (GB)" = ($_.IssueWarningQuota.ToString().Split("(")[0]).Split(" GB") | Select-Object -First 1
+          "Max Mailbox Size (GB)" = ($_.ProhibitSendReceiveQuota.ToString().Split("(")[0]).Split(" GB") | Select-Object -First 1
+          "Mailbox Free Space (GB)" = (($_.ProhibitSendReceiveQuota.ToString().Split("(")[0]).Split(" GB") | Select-Object -First 1) - (ConvertTo-Gb -size $mailboxSize.TotalItemSize.ToString().Split("(")[0])
           "Archive Size (GB)" = $archiveSize
           "Archive Items Count" = $archiveResult.ItemCount
+          "Archive Mailbox Free Space (GB)*" = (ConvertTo-Gb -size $_.ArchiveQuota.ToString().Split("(")[0]) - $archiveSize
           "Archive Deleted Items Count" = $archiveResult.DeletedItemCount
-          "Archive Warning Quota (GB)" = $_.ArchiveWarningQuota.ToString().Split("(")[0]
+          "Archive Warning Quota (GB)" = ($_.ArchiveWarningQuota.ToString().Split("(")[0]).Split(" GB") | Select-Object -First 1
           "Archive Quota (GB)" = ConvertTo-Gb -size $_.ArchiveQuota.ToString().Split("(")[0]
         }
 
@@ -209,19 +197,16 @@ Function Get-MailboxStats {
 # Connect to Exchange Online
 ConnectTo-EXO
 
-# Get mailbox status
-Get-MailboxStats | Export-CSV -Path $path -NoTypeInformation -Encoding UTF8
-
-if ((Get-Item $path).Length -gt 0) {
-  Write-Host "Report finished and saved in $path" -ForegroundColor Green
-}else{
-  Write-Host "Failed to create report" -ForegroundColor Red
+If ($CSVpath) {
+    # Get mailbox status
+    Get-MailboxStats | Export-CSV -Path $CSVpath -NoTypeInformation -Encoding UTF8
+    if ((Get-Item $CSVpath).Length -gt 0) {
+        Write-Host "Report finished and saved in $CSVpath" -ForegroundColor Green
+    } 
+    else {
+        Write-Host "Failed to create report" -ForegroundColor Red
+    }
 }
-
-
-# Close Exchange Online Connection
-$close = Read-Host Close Exchange Online connection? [Y] Yes [N] No 
-
-if ($close -match "[yY]") {
-  Disconnect-ExchangeOnline -Confirm:$false | Out-Null
+Else {
+    Get-MailboxStats
 }


### PR DESCRIPTION
Added mailbox free space reporting
Added Archive Mailbox free space reporting (has a '*' as many plans have auto-expanding archives but may be nice to know when a mailbox is close)
Added new example
Modified version, modified by and modified date 
Made the CSV file optional so we can see output in the shell
All output is int32 instead of string with " GB", cleans the output data and makes it easier to work with
