### PR TITLE
$role = $_.DisplayName seems to be case sensitive

### DIFF
--- a/MsGraph/Get-MgMFAStatus.ps1
+++ b/MsGraph/Get-MgMFAStatus.ps1
@@ -130,7 +130,7 @@ Function Get-Admins{
   #>
   process{
     $admins = Get-MgDirectoryRole | Select-Object DisplayName, Id | 
-                %{$role = $_.displayName; Get-MgDirectoryRoleMember -DirectoryRoleId $_.id | 
+                %{$role = $_.DisplayName; Get-MgDirectoryRoleMember -DirectoryRoleId $_.id | 
                   where {$_.AdditionalProperties."@odata.type" -eq "#microsoft.graph.user"} | 
                   % {Get-MgUser -userid $_.id | Where-Object {($_.AssignedLicenses).count -gt 0}}
                 } | 


### PR DESCRIPTION
$role = $_.DisplayName seems to be case sensitive  At least I was not able to retrieve data with a lower case **d**isplayName. After changing the first letter to a capital **D**isplayName I could retrieve the Role of each Member. Please check and verify.
Thanks.

I used this version of the Module *bit outdated*
```
Get-InstalledModule Microsoft.Graph.Users

Version              Name                                Repository           Description
-------              ----                                ----------           -----------
1.12.3               Microsoft.Graph.Users               PSGallery            Microsoft Graph PowerShell Cmdlets
```