### PR TITLE
Get-MgUser attribute ObjectId was renamed to Id

### DIFF
--- a/MsGraph/Get-MgMFAStatus.ps1
+++ b/MsGraph/Get-MgMFAStatus.ps1
@@ -134,7 +134,7 @@ Function Get-Admins{
                   where {$_.AdditionalProperties."@odata.type" -eq "#microsoft.graph.user"} | 
                   % {Get-MgUser -userid $_.id | Where-Object {($_.AssignedLicenses).count -gt 0}}
                 } | 
-                Select @{Name="Role"; Expression = {$role}}, DisplayName, UserPrincipalName, Mail, ObjectId | Sort-Object -Property Mail -Unique
+                Select @{Name="Role"; Expression = {$role}}, DisplayName, UserPrincipalName, Mail, Id | Sort-Object -Property Mail -Unique
     
     return $admins
   }


### PR DESCRIPTION
Get-MgUser attribute ObjectId was renamed to Id
Please check and verify, e.g. with cmdlet (no attribute ObjectId returned): `Get-MgUser -Top 1 | Select-Object *Id*`