### PR TITLE
Added prompt to open browser to the new rule

### DIFF
--- a/Exchange/MailboxStorageReport.ps1
+++ b/Exchange/MailboxStorageReport.ps1
@@ -1,0 +1,15 @@
+Connect-ExchangeOnline -UserPrincipalName ryanfrenz@StandleyBatch.onmicrosoft.com
+
+$MailboxStorage = Get-Mailbox -ResultSize Unlimited | ForEach-Object {
+    $PrimaryStats = Get-MailboxStatistics $_.Identity
+    $ArchiveStats = if ($_.ArchiveStatus -eq "Active") { Get-MailboxStatistics -Archive $_.Identity } else { $null }
+    [PSCustomObject]@{
+        User               = $_.DisplayName
+        PrimaryMailboxSize = $PrimaryStats.TotalItemSize.Value.ToString()
+        ArchiveMailboxSize = if ($ArchiveStats) { $ArchiveStats.TotalItemSize.Value.ToString() } else { "No Archive" }
+        PrimaryItemCount   = $PrimaryStats.ItemCount
+        ArchiveItemCount   = if ($ArchiveStats) { $ArchiveStats.ItemCount } else { "No Archive" }
+    }
+}
+
+$MailboxStorage | Export-Csv -Path "MailboxStorageReport.csv" -NoTypeInformation -Encoding UTF8

--- a/Exchange/MailboxStorageReport.ps1
+++ b/Exchange/MailboxStorageReport.ps1
@@ -1,4 +1,4 @@
-Connect-ExchangeOnline -UserPrincipalName ryanfrenz@StandleyBatch.onmicrosoft.com
+Connect-ExchangeOnline -UserPrincipalName johndoe@contoso.com
 
 $MailboxStorage = Get-Mailbox -ResultSize Unlimited | ForEach-Object {
     $PrimaryStats = Get-MailboxStatistics $_.Identity

--- a/Phishing Mail Warning/AddPhishingMailWarning.ps1
+++ b/Phishing Mail Warning/AddPhishingMailWarning.ps1
@@ -19,7 +19,7 @@ $HTMLDisclaimer = '<table border=0 cellspacing=0 cellpadding=0 align="left" widt
 Write-Host "Creating Transport Rule" -ForegroundColor Cyan
 
 # Create new Transport Rule
-New-TransportRule -Name "External Email Warning test" `
+New-TransportRule -Name "Phishing Warning" `
 									-FromScope NotInOrganization `
 									-SentToScope InOrganization `
 									-SubjectOrBodyMatchesPatterns (Get-Content $PSScriptRoot\PhishingPatterns.txt) `

--- a/Phishing Mail Warning/ImpersonationMailWarning.ps1
+++ b/Phishing Mail Warning/ImpersonationMailWarning.ps1
@@ -50,6 +50,9 @@ Function Remove-ExistingRules {
 # Get all existing users
 $displayNames = (Get-EXOMailbox -ResultSize unlimited  -RecipientTypeDetails usermailbox).displayname
 
+#sort the display names
+$displaynames = $displayNames | Sort-Object
+
 # Set the transport rule name
 $transportRuleName = "Impersonation warning"
 
@@ -128,6 +131,22 @@ else {
                     -ApplyHtmlDisclaimerFallbackAction Wrap
 
   Write-Host "Transport rule created" -ForegroundColor Green
+}
+
+# Get the transport rules again so we can open a browser directly to it (only link to the first rule found)
+$existingTransportRule = Get-TransportRule | Where-Object {$_.Name -like $transportRuleName+"*"} | Select-Object -First 1
+
+#build the URL
+$urlPrefix = "https://admin.exchange.microsoft.com/#/transportrules/:/ruleDetails/"
+$ruleURL = $urlPrefix + $existingtransportrule.Guid + "/viewinflyoutpanel"
+
+# Open a browser to the Transport Rule
+write-host "Rule URL: " -NoNewline
+write-host $ruleURL -ForegroundColor Cyan
+$OpenInProwser = Read-Host Open browser to URL? [Y] Yes [N] No 
+
+if ($OpenInProwser -match "[yY]") {
+  Start-Process $ruleURL
 }
 
 # Close Exchange Online Connection


### PR DESCRIPTION
Features added:

1. display names are sorted before creating the rules.
2. After creating the rules, a the user is prompted to open a browser directly to the transport rule in the exchange admin center.